### PR TITLE
np.cov shape bug with ndarray type=object

### DIFF
--- a/blazeit/aggregation/samplers.py
+++ b/blazeit/aggregation/samplers.py
@@ -27,7 +27,7 @@ class Sampler(object):
         return Y_pred, Y_true
 
     def sample(self):
-        Y_pred, Y_true = self.permute(self.Y_pred, self.Y_true)
+        Y_pred, Y_true = self.permute(self.Y_pred.astype(np.float32), self.Y_true.astype(np.float32))
         self.reset(Y_pred, Y_true)
 
         LB = -10000000


### PR DESCRIPTION
similar pr as last time, just on the default sampler now as well.